### PR TITLE
feat: Add payload-based namespace selection for audit log events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 0.0.4 - 2026-02-02
+
+### Added
+
+- Support for dynamic namespace selection via event payload (`AuditLogNG.NAMESPACE_ATTRIBUTE`)
+
 ## Version 0.0.3 - 2026-01-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ By default, the namespace used in audit log events is taken from the service bin
 
 Set the namespace directly in the event payload using the key `auditlog.namespace`. This approach **survives transactional outbox serialization**, ensuring the custom namespace is preserved even when events are processed asynchronously through the outbox.
 
-> **Important:** The key must be exactly `"auditlog.namespace"` - this string is required!
+> **Important:** The key must be exactly `"auditlog.namespace"`. You can also use the constant `AuditLogNG.NAMESPACE_ATTRIBUTE`.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -101,61 +101,62 @@ To get your project running, ensure you have the following prerequisites:
 
 By default, the namespace used in audit log events is taken from the service binding credentials. However, applications that need to route audit events to different namespaces dynamically (e.g., applications with multiple commercial offerings sharing the same deployed services) can override the namespace per-request.
 
-### How to Use
+### Recommended: Payload-based Namespace (Outbox-safe)
 
-Set the user attribute `auditlog.namespace` in the `UserInfo` object. If this attribute is present and non-empty, it will be used instead of the namespace from the service binding.
+Set the namespace directly in the event payload using the key `auditlog.namespace`. This approach **survives transactional outbox serialization** and is the recommended way to set custom namespaces.
 
-#### Example: Custom UserInfoProvider
+#### Examples
 
 ```java
-import org.springframework.stereotype.Component;
-import com.sap.cds.services.runtime.UserInfoProvider;
-import com.sap.cds.services.request.UserInfo;
-import com.sap.cds.services.request.ModifiableUserInfo;
+// Security Event
+SecurityLog securityLog = SecurityLog.create();
+securityLog.setAction("login");
+securityLog.setData("User logged in");
+securityLog.put("auditlog.namespace", "my-custom-namespace");
+auditLogService.logSecurity(securityLog);
 
-@Component
-public class CustomUserInfoProvider implements UserInfoProvider {
+// Data Access Event
+DataAccessLog dataAccessLog = DataAccessLog.create();
+dataAccessLog.setAccesses(List.of(access));
+dataAccessLog.put("auditlog.namespace", "my-custom-namespace");
+auditLogService.logDataAccess(dataAccessLog);
 
-    private UserInfoProvider defaultProvider;
+// Config Change Event
+ConfigChangeLog configChangeLog = ConfigChangeLog.create();
+configChangeLog.setConfigurations(List.of(configChange));
+configChangeLog.put("auditlog.namespace", "my-custom-namespace");
+auditLogService.logConfigChange(configChangeLog);
 
-    @Override
-    public UserInfo get() {
-        ModifiableUserInfo userInfo = UserInfo.create();
-        if (defaultProvider != null) {
-            UserInfo prevUserInfo = defaultProvider.get();
-            if (prevUserInfo != null) {
-                userInfo = prevUserInfo.copy();
-            }
-        }
-        
-        // Determine namespace based on your application context
-        String namespace = determineNamespaceForCurrentContext();
-        userInfo.setAttributeValue("auditlog.namespace", namespace);
-        
-        return userInfo;
-    }
-
-    @Override
-    public void setPrevious(UserInfoProvider prev) {
-        this.defaultProvider = prev;
-    }
-    
-    private String determineNamespaceForCurrentContext() {
-        // Your logic to determine the appropriate namespace
-        // e.g., based on subscription plan, application variant, etc.
-        return "my-custom-namespace";
-    }
-}
+// Data Modification Event
+DataModificationLog dataModificationLog = DataModificationLog.create();
+dataModificationLog.setModifications(List.of(modification));
+dataModificationLog.put("auditlog.namespace", "my-custom-namespace");
+auditLogService.logDataModification(dataModificationLog);
 ```
+
+### Deprecated: UserInfo Attribute
+
+> **Warning:** Setting the namespace via `UserInfo` attributes is **deprecated** and does **NOT work reliably** with the transactional outbox. User attributes may be lost during outbox serialization/deserialization. Please use the payload-based approach instead.
+
+The deprecated approach using `UserInfo.setAttributeValue("auditlog.namespace", namespace)` will still work for direct (non-outbox) calls, but a warning will be logged when this approach is detected.
+
+### Resolution Priority
+
+The namespace is resolved in the following order:
+
+1. **Payload** (recommended): `payload.get("auditlog.namespace")`
+2. **UserInfo attribute** (deprecated): `userInfo.getAttributeValues("auditlog.namespace")`
+3. **Service binding**: Namespace from the service binding credentials
 
 ### Behavior
 
 | Scenario | Namespace Used |
 |----------|---------------|
-| `auditlog.namespace` attribute is set with a valid value | Custom namespace from attribute |
-| `auditlog.namespace` attribute is empty or whitespace-only | Namespace from service binding |
-| `auditlog.namespace` attribute is not set | Namespace from service binding |
-| Multiple values provided in the attribute | First non-empty value is used |
+| `auditlog.namespace` set in payload | Custom namespace from payload |
+| `auditlog.namespace` set in UserInfo only | Custom namespace from UserInfo (with deprecation warning) |
+| Both payload and UserInfo set | Payload takes precedence |
+| Namespace is empty or whitespace-only | Falls back to next priority level |
+| No custom namespace set | Namespace from service binding |
 
 > **Note:** The custom namespace value is trimmed of leading/trailing whitespace before use.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,68 @@ To get your project running, ensure you have the following prerequisites:
 - A user-provided service instance for SAP Audit Log service created in your Cloud Foundry space
 - The Maven dependency for `cds-feature-auditlog-ng` added to your project
 
+## Dynamic Namespace Selection
+
+By default, the namespace used in audit log events is taken from the service binding credentials. However, applications that need to route audit events to different namespaces dynamically (e.g., applications with multiple commercial offerings sharing the same deployed services) can override the namespace per-request.
+
+### How to Use
+
+Set the user attribute `auditlog.namespace` in the `UserInfo` object. If this attribute is present and non-empty, it will be used instead of the namespace from the service binding.
+
+#### Example: Custom UserInfoProvider
+
+```java
+import org.springframework.stereotype.Component;
+import com.sap.cds.services.runtime.UserInfoProvider;
+import com.sap.cds.services.request.UserInfo;
+import com.sap.cds.services.request.ModifiableUserInfo;
+
+@Component
+public class CustomUserInfoProvider implements UserInfoProvider {
+
+    private UserInfoProvider defaultProvider;
+
+    @Override
+    public UserInfo get() {
+        ModifiableUserInfo userInfo = UserInfo.create();
+        if (defaultProvider != null) {
+            UserInfo prevUserInfo = defaultProvider.get();
+            if (prevUserInfo != null) {
+                userInfo = prevUserInfo.copy();
+            }
+        }
+        
+        // Determine namespace based on your application context
+        String namespace = determineNamespaceForCurrentContext();
+        userInfo.setAttributeValue("auditlog.namespace", namespace);
+        
+        return userInfo;
+    }
+
+    @Override
+    public void setPrevious(UserInfoProvider prev) {
+        this.defaultProvider = prev;
+    }
+    
+    private String determineNamespaceForCurrentContext() {
+        // Your logic to determine the appropriate namespace
+        // e.g., based on subscription plan, application variant, etc.
+        return "my-custom-namespace";
+    }
+}
+```
+
+### Behavior
+
+| Scenario | Namespace Used |
+|----------|---------------|
+| `auditlog.namespace` attribute is set with a valid value | Custom namespace from attribute |
+| `auditlog.namespace` attribute is empty or whitespace-only | Namespace from service binding |
+| `auditlog.namespace` attribute is not set | Namespace from service binding |
+| Multiple values provided in the attribute | First non-empty value is used |
+
+> **Note:** The custom namespace value is trimmed of leading/trailing whitespace before use.
+
 ## Support, Feedback, Contributing
 
 This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/cap-java/cds-feature-auditlog-ng/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -97,13 +97,17 @@ To get your project running, ensure you have the following prerequisites:
 - A user-provided service instance for SAP Audit Log service created in your Cloud Foundry space
 - The Maven dependency for `cds-feature-auditlog-ng` added to your project
 
-## Dynamic Namespace Selection
+## Dynamic Namespace Selection (Optional)
 
-By default, the namespace used in audit log events is taken from the service binding credentials. However, applications that need to route audit events to different namespaces dynamically (e.g., applications with multiple commercial offerings sharing the same deployed services) can override the namespace per-request.
+By default, the namespace used in audit log events is taken from the service binding credentials. This is sufficient for most applications.
+
+**Optional:** For applications that need to route audit events to different namespaces, the namespace can be overridden per-event using the payload.
 
 ### Payload-based Namespace
 
-Set the namespace directly in the event payload using the key `auditlog.namespace`. This approach **survives transactional outbox serialization**.
+Set the namespace directly in the event payload using the key `auditlog.namespace`. This approach **survives transactional outbox serialization**, ensuring the custom namespace is preserved even when events are processed asynchronously through the outbox.
+
+> **Important:** The key must be exactly `"auditlog.namespace"` - this string is required!
 
 #### Examples
 
@@ -150,6 +154,10 @@ The namespace is resolved in the following order:
 | No custom namespace set | Namespace from service binding |
 
 > **Note:** The custom namespace value is trimmed of leading/trailing whitespace before use.
+
+### Error Handling
+
+If you specify a custom namespace that is not registered in the SAP Audit Log service, the service will reject the event with a 403 Forbidden error. Ensure all custom namespaces are properly registered before use.
 
 ## Support, Feedback, Contributing
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ To get your project running, ensure you have the following prerequisites:
 
 By default, the namespace used in audit log events is taken from the service binding credentials. However, applications that need to route audit events to different namespaces dynamically (e.g., applications with multiple commercial offerings sharing the same deployed services) can override the namespace per-request.
 
-### Recommended: Payload-based Namespace (Outbox-safe)
+### Payload-based Namespace
 
-Set the namespace directly in the event payload using the key `auditlog.namespace`. This approach **survives transactional outbox serialization** and is the recommended way to set custom namespaces.
+Set the namespace directly in the event payload using the key `auditlog.namespace`. This approach **survives transactional outbox serialization**.
 
 #### Examples
 
@@ -134,28 +134,19 @@ dataModificationLog.put("auditlog.namespace", "my-custom-namespace");
 auditLogService.logDataModification(dataModificationLog);
 ```
 
-### Deprecated: UserInfo Attribute
-
-> **Warning:** Setting the namespace via `UserInfo` attributes is **deprecated** and does **NOT work reliably** with the transactional outbox. User attributes may be lost during outbox serialization/deserialization. Please use the payload-based approach instead.
-
-The deprecated approach using `UserInfo.setAttributeValue("auditlog.namespace", namespace)` will still work for direct (non-outbox) calls, but a warning will be logged when this approach is detected.
-
 ### Resolution Priority
 
 The namespace is resolved in the following order:
 
-1. **Payload** (recommended): `payload.get("auditlog.namespace")`
-2. **UserInfo attribute** (deprecated): `userInfo.getAttributeValues("auditlog.namespace")`
-3. **Service binding**: Namespace from the service binding credentials
+1. **Payload**: `payload.get("auditlog.namespace")`
+2. **Service binding**: Namespace from the service binding credentials
 
 ### Behavior
 
 | Scenario | Namespace Used |
 |----------|---------------|
 | `auditlog.namespace` set in payload | Custom namespace from payload |
-| `auditlog.namespace` set in UserInfo only | Custom namespace from UserInfo (with deprecation warning) |
-| Both payload and UserInfo set | Payload takes precedence |
-| Namespace is empty or whitespace-only | Falls back to next priority level |
+| Namespace is empty or whitespace-only | Falls back to service binding |
 | No custom namespace set | Namespace from service binding |
 
 > **Note:** The custom namespace value is trimmed of leading/trailing whitespace before use.

--- a/cds-feature-auditlog-ng/src/main/java/com/sap/cds/feature/auditlog/ng/AuditLogNG.java
+++ b/cds-feature-auditlog-ng/src/main/java/com/sap/cds/feature/auditlog/ng/AuditLogNG.java
@@ -1,0 +1,17 @@
+package com.sap.cds.feature.auditlog.ng;
+
+/**
+ * Constants for the AuditLog NG plugin.
+ */
+public interface AuditLogNG {
+    /**
+     * Key name for specifying a custom namespace in the event payload.
+     * 
+     * <p>Set this key directly in the event payload 
+     * (e.g., {@code securityLog.put(AuditLogNG.NAMESPACE_ATTRIBUTE, "my-namespace")}).
+     * This approach survives transactional outbox serialization.</p>
+     * 
+     * <p>Resolution priority: payload &gt; service binding</p>
+     */
+    String NAMESPACE_ATTRIBUTE = "auditlog.namespace";
+}

--- a/cds-feature-auditlog-ng/src/main/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandler.java
+++ b/cds-feature-auditlog-ng/src/main/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandler.java
@@ -8,6 +8,7 @@ import static org.slf4j.LoggerFactory.*;
 
 import java.time.Instant;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -48,6 +49,12 @@ import com.sap.cds.services.utils.ErrorStatusException;
 
 /**
  * Handler that reacts on audit log events to log audit messages with the auditlog NG API.
+ *
+ * <p>The namespace used in the event source can be customized per-request by setting
+ * the user attribute {@value #NAMESPACE_ATTRIBUTE}. If this attribute is present and non-empty,
+ * it will be used instead of the namespace from the service binding. This allows
+ * applications with multiple commercial offerings to route audit events to different
+ * namespaces dynamically.</p>
  */
 @ServiceName(value = "*", type = AuditLogService.class)
 public class AuditLogNGHandler implements EventHandler {
@@ -55,6 +62,12 @@ public class AuditLogNGHandler implements EventHandler {
     private static final Logger LOGGER = getLogger(AuditLogNGHandler.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String LEGACY_SECURITY_WRAPPER = "legacySecurityWrapper";
+    
+    /**
+     * User attribute name for specifying a custom namespace.
+     * When set, this namespace overrides the one from the service binding.
+     */
+    static final String NAMESPACE_ATTRIBUTE = "auditlog.namespace";
 
     private final AuditLogNGCommunicator communicator;
     private final TenantProviderService tenantService;
@@ -395,12 +408,13 @@ public class AuditLogNGHandler implements EventHandler {
      *
      * The envelope includes a unique event ID, specification version, source,
      * type, and timestamp. The source is constructed using the communicator's
-     * region, namespace, and the tenant information. If the tenant is not
-     * provided in the UserInfo, the provider tenant is used.
+     * region, the resolved namespace (which may come from user attributes or the binding),
+     * and the tenant information. If the tenant is not provided in the UserInfo,
+     * the provider tenant is used.
      *
      * @param mapper the ObjectMapper used to create the JSON object node
      * @param type the type of the event to be set in the envelope
-     * @param userInfo the user information containing tenant details
+     * @param userInfo the user information containing tenant details and optional namespace override
      * @return an ObjectNode representing the event envelope
      */
     private ObjectNode buildEventEnvelope(ObjectMapper mapper, String type, UserInfo userInfo) {
@@ -408,10 +422,34 @@ public class AuditLogNGHandler implements EventHandler {
         alsEvent.put("id", UUID.randomUUID().toString());
         alsEvent.put("specversion", "1");
         String tenant = (userInfo.getTenant() == null || userInfo.getTenant().isEmpty()) ? tenantService.readProviderTenant() : userInfo.getTenant();
-        alsEvent.put("source", String.format("/%s/%s/%s", communicator.getRegion(), communicator.getNamespace(), tenant));
+        String namespace = resolveNamespace(userInfo);
+        alsEvent.put("source", String.format("/%s/%s/%s", communicator.getRegion(), namespace, tenant));
         alsEvent.put("type", type);
         alsEvent.put("time", Instant.now().toString());
         return alsEvent;
+    }
+
+    /**
+     * Resolves the namespace for the audit log event.
+     * 
+     * <p>First checks if a custom namespace is provided via the user attribute
+     * {@value #NAMESPACE_ATTRIBUTE}. If found and valid (non-empty, no whitespace-only),
+     * it will be used. Otherwise, falls back to the namespace from the service binding.</p>
+     *
+     * @param userInfo the user information containing potential custom attributes
+     * @return the namespace to use for the event source
+     */
+    private String resolveNamespace(UserInfo userInfo) {
+        List<String> namespaceValues = userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE);
+        if (namespaceValues != null && !namespaceValues.isEmpty()) {
+            String customNamespace = namespaceValues.get(0);
+            if (customNamespace != null && !customNamespace.trim().isEmpty()) {
+                LOGGER.debug("Using custom namespace from user attribute '{}': {}", NAMESPACE_ATTRIBUTE, customNamespace);
+                return customNamespace.trim();
+            }
+        }
+        LOGGER.debug("No custom namespace found in user attributes, using binding namespace: {}", communicator.getNamespace());
+        return communicator.getNamespace();
     }
 
     /**

--- a/cds-feature-auditlog-ng/src/main/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandler.java
+++ b/cds-feature-auditlog-ng/src/main/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandler.java
@@ -38,7 +38,6 @@ import com.sap.cds.services.auditlog.DataSubject;
 import com.sap.cds.services.auditlog.KeyValuePair;
 import com.sap.cds.services.auditlog.SecurityLog;
 import com.sap.cds.services.auditlog.SecurityLogContext;
-import com.sap.cds.services.environment.CdsProperties.Security.Mock.User;
 import com.sap.cds.services.handler.EventHandler;
 import com.sap.cds.services.handler.annotations.On;
 import com.sap.cds.services.handler.annotations.ServiceName;
@@ -417,13 +416,13 @@ public class AuditLogNGHandler implements EventHandler {
      *
      * The envelope includes a unique event ID, specification version, source,
      * type, and timestamp. The source is constructed using the communicator's
-     * region, the resolved namespace (which may come from payload, user attributes, or the binding),
+     * region, the resolved namespace (which may come from payload or the binding),
      * and the tenant information. If the tenant is not provided in the UserInfo,
      * the provider tenant is used.
      *
      * @param mapper the ObjectMapper used to create the JSON object node
      * @param type the type of the event to be set in the envelope
-     * @param userInfo the user information containing tenant details and optional namespace override
+     * @param userInfo the user information containing tenant details
      * @param payload the event payload that may contain a custom namespace, can be null
      * @return an ObjectNode representing the event envelope
      */

--- a/cds-feature-auditlog-ng/src/main/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandler.java
+++ b/cds-feature-auditlog-ng/src/main/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandler.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sap.cds.CdsData;
 import com.sap.cds.services.EventContext;
 import com.sap.cds.services.auditlog.Access;
 import com.sap.cds.services.auditlog.Attachment;
@@ -64,8 +65,17 @@ public class AuditLogNGHandler implements EventHandler {
     private static final String LEGACY_SECURITY_WRAPPER = "legacySecurityWrapper";
     
     /**
-     * User attribute name for specifying a custom namespace.
-     * When set, this namespace overrides the one from the service binding.
+     * Key name for specifying a custom namespace (used in both payload and UserInfo attributes).
+     * 
+     * <p><strong>Recommended approach (outbox-safe):</strong> Set this key directly in the
+     * event payload (e.g., {@code securityLog.put("auditlog.namespace", "my-namespace")}).
+     * This approach survives transactional outbox serialization.</p>
+     * 
+     * <p><strong>Deprecated approach:</strong> Setting via UserInfo attribute does NOT work
+     * reliably with the transactional outbox as user attributes may be lost during serialization.
+     * A warning will be logged when this approach is detected.</p>
+     * 
+     * <p>Resolution priority: payload &gt; UserInfo attribute &gt; service binding</p>
      */
     static final String NAMESPACE_ATTRIBUTE = "auditlog.namespace";
 
@@ -118,7 +128,8 @@ public class AuditLogNGHandler implements EventHandler {
         Map<String, Object> data = (Map<String, Object>) context.get("data");
         String eventJson = (String) data.get("event");
 
-        ObjectNode eventEnvelope = buildEventEnvelope(OBJECT_MAPPER, eventType, userInfo);
+        // General events don't support payload-based namespace override
+        ObjectNode eventEnvelope = buildEventEnvelope(OBJECT_MAPPER, eventType, userInfo, null);
         ObjectNode metadata = buildEventMetadata(userInfo);
         ObjectNode parsedEventNode = (ObjectNode) OBJECT_MAPPER.readTree(eventJson);
         ObjectNode wrappedDataNode = OBJECT_MAPPER.createObjectNode();
@@ -158,7 +169,7 @@ public class AuditLogNGHandler implements EventHandler {
     private ArrayNode createSecurityEvent(SecurityLogContext context) {
         SecurityLog data = requireNonNull(context.getData(), "SecurityLogContext.getData() is null");
         UserInfo userInfo = requireNonNull(context.getUserInfo(), "SecurityLogContext.getUserInfo() is null");
-        ObjectNode alsEvent = buildEventEnvelope(OBJECT_MAPPER, LEGACY_SECURITY_WRAPPER, userInfo);
+        ObjectNode alsEvent = buildEventEnvelope(OBJECT_MAPPER, LEGACY_SECURITY_WRAPPER, userInfo, data);
         ObjectNode metadata = buildEventMetadata(userInfo);
         ObjectNode origEvent = createLegacySecurityOrigEvent(userInfo, data);
         ObjectNode legacySecurityWrapper = OBJECT_MAPPER.createObjectNode();
@@ -223,7 +234,7 @@ public class AuditLogNGHandler implements EventHandler {
         Collection<Access> accesses = requireNonNull(data.getAccesses(), "DataAccessLog.getAccesses() is null");
         ArrayNode eventArray = OBJECT_MAPPER.createArrayNode();
         for (Access access : accesses) {
-            addAccessEvents(userInfo, eventArray, access);
+            addAccessEvents(userInfo, eventArray, access, data);
         }
         return eventArray;
     }
@@ -236,13 +247,14 @@ public class AuditLogNGHandler implements EventHandler {
      * @param userInfo   the user information associated with the access event
      * @param eventArray the array to which access events will be added
      * @param access     the access object containing the attributes to process
+     * @param payload    the event payload that may contain a custom namespace
      * @throws NullPointerException if {@code access.getAttributes()} or any attribute name is {@code null}
      */
-    private void addAccessEvents(UserInfo userInfo, ArrayNode eventArray, Access access) {
+    private void addAccessEvents(UserInfo userInfo, ArrayNode eventArray, Access access, CdsData payload) {
         Collection<Attribute> attributes = requireNonNull(access.getAttributes(), "Access.getAttributes() is null");
         for (Attribute attribute : attributes) {
             String attributeName = requireNonNull(attribute.getName(), "Attribute.getName() is null");
-            addAttributeAccessEvents(userInfo, eventArray, access, attributeName);
+            addAttributeAccessEvents(userInfo, eventArray, access, attributeName, payload);
         }
     }
 
@@ -255,15 +267,16 @@ public class AuditLogNGHandler implements EventHandler {
      * @param eventArray    the JSON array node to which the generated events will be added
      * @param access        the access object containing details about the attribute access and any attachments
      * @param attributeName the name of the attribute being accessed
+     * @param payload       the event payload that may contain a custom namespace
      */
-    private void addAttributeAccessEvents(UserInfo userInfo, ArrayNode eventArray, Access access, String attributeName) {
+    private void addAttributeAccessEvents(UserInfo userInfo, ArrayNode eventArray, Access access, String attributeName, CdsData payload) {
         Collection<Attachment> attachments = access.getAttachments();
         if (attachments == null || attachments.isEmpty()) {
-            ObjectNode alsEvent = buildDataAccessAlsEvent(userInfo, access, attributeName, null, null);
+            ObjectNode alsEvent = buildDataAccessAlsEvent(userInfo, access, attributeName, null, null, payload);
             eventArray.add(alsEvent);
         } else {
             for (Attachment attachment : attachments) {
-                ObjectNode alsEvent = buildDataAccessAlsEvent(userInfo, access, attributeName, attachment.getName(), attachment.getId());
+                ObjectNode alsEvent = buildDataAccessAlsEvent(userInfo, access, attributeName, attachment.getName(), attachment.getId(), payload);
                 eventArray.add(alsEvent);
             }
         }
@@ -292,7 +305,7 @@ public class AuditLogNGHandler implements EventHandler {
         ArrayNode result = OBJECT_MAPPER.createArrayNode();
         configChanges.forEach(cfg -> {
             Collection<ChangedAttribute> attributes = requireNonNull(cfg.getAttributes(), "ConfigChange.getAttributes() is null");
-            attributes.stream().map(attribute -> buildConfigChangeEvent(userInfo, cfg, attribute)).forEach(result::add);
+            attributes.stream().map(attribute -> buildConfigChangeEvent(userInfo, cfg, attribute, data)).forEach(result::add);
         });
         return result;
     }
@@ -302,18 +315,19 @@ public class AuditLogNGHandler implements EventHandler {
      * This method constructs an ObjectNode representing an audit log event for a configuration change,
      * including metadata, details about the changed attribute, and information about the affected data object.
      *
-     * @param context   the context containing user and request information for the configuration change
+     * @param userInfo  the user information for the configuration change
      * @param cfg       the configuration change object containing details about the change
      * @param attribute the specific attribute that was changed
+     * @param payload   the event payload that may contain a custom namespace
      * @return an ObjectNode representing the audit log event for the configuration change
      */
-    private ObjectNode buildConfigChangeEvent(UserInfo userInfo, ConfigChange configChanges, ChangedAttribute attribute) {
+    private ObjectNode buildConfigChangeEvent(UserInfo userInfo, ConfigChange configChanges, ChangedAttribute attribute, CdsData payload) {
         ObjectNode metadata = buildEventMetadata(userInfo);
         ObjectNode changeNode = OBJECT_MAPPER.createObjectNode();
         addValueDetails(changeNode, attribute, "propertyName");
         var dataObject = requireNonNull(configChanges.getDataObject(), "ConfigChange.getDataObject() is null");
         addObjectDetails(changeNode, dataObject);
-        return buildAlsEvent("configurationChange", userInfo, metadata, "configurationChange", changeNode);
+        return buildAlsEvent("configurationChange", userInfo, metadata, "configurationChange", changeNode, payload);
     }
 
     public void handleDataModificationEvent(DataModificationLogContext context) throws JsonProcessingException {
@@ -335,7 +349,7 @@ public class AuditLogNGHandler implements EventHandler {
         DataModificationLog data = requireNonNull(context.getData(), "DataModificationLogContext.getData() is null");
         Collection<DataModification> modifications = requireNonNull(data.getModifications(), "DataModificationLog.getModifications() is null");
         UserInfo userInfo = requireNonNull(context.getUserInfo(), "DataModificationLogContext.getUserInfo() is null");
-        return buildAttributeBasedAlsEvents(userInfo, modifications);
+        return buildAttributeBasedAlsEvents(userInfo, modifications, data);
     }
 
     /**
@@ -343,17 +357,18 @@ public class AuditLogNGHandler implements EventHandler {
      * For each {@link DataModification} in the provided collection, this method iterates through its changed attributes
      * and creates an ALS event for each attribute using {@code buildDataModificationAlsEvent}.
      *
-     * @param context the context of the data modification log, containing relevant metadata for event creation
-     * @param items a collection of {@link DataModification} objects to process
+     * @param userInfo the user information for the events
+     * @param modifications a collection of {@link DataModification} objects to process
+     * @param payload the event payload that may contain a custom namespace
      * @return an {@link ArrayNode} containing the generated ALS events for each changed attribute
      * @throws IllegalArgumentException if any {@link DataModification} item has no attributes
      */
-    private ArrayNode buildAttributeBasedAlsEvents(UserInfo userInfo, Collection<DataModification> modifications) {
+    private ArrayNode buildAttributeBasedAlsEvents(UserInfo userInfo, Collection<DataModification> modifications, CdsData payload) {
         ArrayNode eventArray = OBJECT_MAPPER.createArrayNode();
         for (DataModification modification : modifications) {
             Collection<ChangedAttribute> attributes = requireNonNull(modification.getAttributes(), "DataModification.getAttributes() is null");
             for (ChangedAttribute attribute : attributes) {
-                eventArray.add(buildDataModificationAlsEvent(userInfo, modification, attribute));
+                eventArray.add(buildDataModificationAlsEvent(userInfo, modification, attribute, payload));
             }
         }
         return eventArray;
@@ -364,16 +379,17 @@ public class AuditLogNGHandler implements EventHandler {
      * This method constructs an ObjectNode representing a data modification event,
      * including relevant metadata, object and subject information, and changed attribute details.
      *
-     * @param context the context of the data modification log, containing user and request information
+     * @param userInfo the user information for the event
      * @param modification the data modification details, including the affected data object and subject
      * @param attribute the specific attribute that was changed during the modification
+     * @param payload the event payload that may contain a custom namespace
      * @return an ObjectNode representing the constructed ALS event for the data modification
      */
-    private ObjectNode buildDataModificationAlsEvent(UserInfo userInfo, DataModification modification, ChangedAttribute attribute) {
+    private ObjectNode buildDataModificationAlsEvent(UserInfo userInfo, DataModification modification, ChangedAttribute attribute, CdsData payload) {
         DataObject dataObject = requireNonNull(modification.getDataObject(), "DataModification.getDataObject() is null");
         ObjectNode metadata = buildEventMetadata(userInfo);
         ObjectNode dataModificationNode = buildDataModificationNode(attribute, modification.getDataSubject(), dataObject);
-        return buildAlsEvent("dppDataModification", userInfo, metadata, "dppDataModification", dataModificationNode);
+        return buildAlsEvent("dppDataModification", userInfo, metadata, "dppDataModification", dataModificationNode, payload);
     }
 
     /**
@@ -408,21 +424,22 @@ public class AuditLogNGHandler implements EventHandler {
      *
      * The envelope includes a unique event ID, specification version, source,
      * type, and timestamp. The source is constructed using the communicator's
-     * region, the resolved namespace (which may come from user attributes or the binding),
+     * region, the resolved namespace (which may come from payload, user attributes, or the binding),
      * and the tenant information. If the tenant is not provided in the UserInfo,
      * the provider tenant is used.
      *
      * @param mapper the ObjectMapper used to create the JSON object node
      * @param type the type of the event to be set in the envelope
      * @param userInfo the user information containing tenant details and optional namespace override
+     * @param payload the event payload that may contain a custom namespace, can be null
      * @return an ObjectNode representing the event envelope
      */
-    private ObjectNode buildEventEnvelope(ObjectMapper mapper, String type, UserInfo userInfo) {
+    private ObjectNode buildEventEnvelope(ObjectMapper mapper, String type, UserInfo userInfo, CdsData payload) {
         ObjectNode alsEvent = mapper.createObjectNode();
         alsEvent.put("id", UUID.randomUUID().toString());
         alsEvent.put("specversion", "1");
         String tenant = (userInfo.getTenant() == null || userInfo.getTenant().isEmpty()) ? tenantService.readProviderTenant() : userInfo.getTenant();
-        String namespace = resolveNamespace(userInfo);
+        String namespace = resolveNamespace(userInfo, payload); 
         alsEvent.put("source", String.format("/%s/%s/%s", communicator.getRegion(), namespace, tenant));
         alsEvent.put("type", type);
         alsEvent.put("time", Instant.now().toString());
@@ -432,23 +449,45 @@ public class AuditLogNGHandler implements EventHandler {
     /**
      * Resolves the namespace for the audit log event.
      * 
-     * <p>First checks if a custom namespace is provided via the user attribute
-     * {@value #NAMESPACE_ATTRIBUTE}. If found and valid (non-empty, no whitespace-only),
-     * it will be used. Otherwise, falls back to the namespace from the service binding.</p>
+     * <p>Resolution priority:</p>
+     * <ol>
+     *   <li><strong>Payload (recommended):</strong> Checks if namespace is set in the event payload
+     *       via {@code payload.get("auditlog.namespace")}. This approach survives outbox serialization.</li>
+     *   <li><strong>UserInfo attribute (deprecated):</strong> Falls back to checking the user attribute
+     *       {@value #NAMESPACE_ATTRIBUTE}. A warning is logged as this approach does not work reliably
+     *       with the transactional outbox.</li>
+     *   <li><strong>Service binding:</strong> Falls back to the namespace from the service binding.</li>
+     * </ol>
      *
      * @param userInfo the user information containing potential custom attributes
+     * @param payload the event payload (CdsData) that may contain a custom namespace, can be null
      * @return the namespace to use for the event source
      */
-    private String resolveNamespace(UserInfo userInfo) {
+    private String resolveNamespace(UserInfo userInfo, CdsData payload) {
+        // Priority 1: Check payload (outbox-safe approach)
+        if (payload != null) {
+            Object namespaceFromPayload = payload.get(NAMESPACE_ATTRIBUTE);
+            if (namespaceFromPayload instanceof String ns && !ns.trim().isEmpty()) {
+                LOGGER.debug("Using custom namespace from payload '{}': {}", NAMESPACE_ATTRIBUTE, ns.trim());
+                return ns.trim();
+            }
+        }
+        
+        // Priority 2: Check UserInfo attributes (deprecated, doesn't survive outbox reliably)
         List<String> namespaceValues = userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE);
         if (namespaceValues != null && !namespaceValues.isEmpty()) {
             String customNamespace = namespaceValues.get(0);
             if (customNamespace != null && !customNamespace.trim().isEmpty()) {
-                LOGGER.debug("Using custom namespace from user attribute '{}': {}", NAMESPACE_ATTRIBUTE, customNamespace);
+                LOGGER.warn("Using namespace from UserInfo attribute '{}'. " +
+                    "This approach is DEPRECATED and may NOT work with the transactional outbox. " +
+                    "Please set the namespace in the event payload instead (e.g., payload.put(\"{}\", \"my-namespace\")).", 
+                    NAMESPACE_ATTRIBUTE, NAMESPACE_ATTRIBUTE);
                 return customNamespace.trim();
             }
         }
-        LOGGER.debug("No custom namespace found in user attributes, using binding namespace: {}", communicator.getNamespace());
+        
+        // Priority 3: Fall back to binding namespace
+        LOGGER.debug("No custom namespace found, using binding namespace: {}", communicator.getNamespace());
         return communicator.getNamespace();
     }
 
@@ -473,17 +512,18 @@ public class AuditLogNGHandler implements EventHandler {
     /**
      * Builds an ALS (Audit Logging Service) event for data access operations.
      *
-     * @param context        the context containing user and request information for the data access event
+     * @param userInfo       the user information for the event
      * @param access         the type of access performed (e.g., READ, WRITE)
      * @param attribute      the specific attribute or field being accessed
      * @param attachmentType the type of attachment associated with the access, if any
      * @param attachmentId   the identifier of the attachment, if applicable
+     * @param payload        the event payload that may contain a custom namespace
      * @return an {@link ObjectNode} representing the constructed ALS event for data access
      */
-    private ObjectNode buildDataAccessAlsEvent(UserInfo userInfo, Access access, String attribute, String attachmentType, String attachmentId) {
+    private ObjectNode buildDataAccessAlsEvent(UserInfo userInfo, Access access, String attribute, String attachmentType, String attachmentId, CdsData payload) {
         ObjectNode metadata = buildEventMetadata(userInfo);
         ObjectNode dataAccessNode = buildDataAccessNode(access, attribute, attachmentType, attachmentId);
-        return buildAlsEvent("dppDataAccess", userInfo, metadata, "dppDataAccess", dataAccessNode);
+        return buildAlsEvent("dppDataAccess", userInfo, metadata, "dppDataAccess", dataAccessNode, payload);
     }
 
     /**
@@ -574,10 +614,11 @@ public class AuditLogNGHandler implements EventHandler {
      * @param metadata the metadata node containing timestamp and other event-specific details
      * @param dataKey the key representing the type of data in the event, e.g., "dppDataAccess"
      * @param dataValue the value node containing the event-specific data
+     * @param payload the event payload that may contain a custom namespace, can be null
      * @return an ObjectNode representing the ALS event
      */
-    private ObjectNode buildAlsEvent(String eventType, UserInfo userInfo, ObjectNode metadata, String dataKey, ObjectNode dataValue) {
-        ObjectNode alsEvent = buildEventEnvelope(OBJECT_MAPPER, eventType, userInfo);
+    private ObjectNode buildAlsEvent(String eventType, UserInfo userInfo, ObjectNode metadata, String dataKey, ObjectNode dataValue, CdsData payload) {
+        ObjectNode alsEvent = buildEventEnvelope(OBJECT_MAPPER, eventType, userInfo, payload);
         ObjectNode dataNode = OBJECT_MAPPER.createObjectNode();
         dataNode.set(dataKey, dataValue);
         ObjectNode alsData = buildAuditLogEventData(metadata, dataNode);

--- a/cds-feature-auditlog-ng/src/main/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandler.java
+++ b/cds-feature-auditlog-ng/src/main/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandler.java
@@ -50,8 +50,10 @@ import com.sap.cds.services.utils.ErrorStatusException;
  * Handler that reacts on audit log events to log audit messages with the auditlog NG API.
  *
  * <p>The namespace used in the event source can be customized per-request by setting
- * the {@value #NAMESPACE_ATTRIBUTE} key in the event payload. This allows applications
+ * the {@link AuditLogNG#NAMESPACE_ATTRIBUTE} key in the event payload. This allows applications
  * with multiple commercial offerings to route audit events to different namespaces dynamically.</p>
+ * 
+ * @see AuditLogNG#NAMESPACE_ATTRIBUTE
  */
 @ServiceName(value = "*", type = AuditLogService.class)
 public class AuditLogNGHandler implements EventHandler {
@@ -59,17 +61,6 @@ public class AuditLogNGHandler implements EventHandler {
     private static final Logger LOGGER = getLogger(AuditLogNGHandler.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String LEGACY_SECURITY_WRAPPER = "legacySecurityWrapper";
-    
-    /**
-     * Key name for specifying a custom namespace in the event payload.
-     * 
-     * <p>Set this key directly in the event payload 
-     * (e.g., {@code securityLog.put("auditlog.namespace", "my-namespace")}).
-     * This approach survives transactional outbox serialization.</p>
-     * 
-     * <p>Resolution priority: payload &gt; service binding</p>
-     */
-    static final String NAMESPACE_ATTRIBUTE = "auditlog.namespace";
 
     private final AuditLogNGCommunicator communicator;
     private final TenantProviderService tenantService;
@@ -455,9 +446,9 @@ public class AuditLogNGHandler implements EventHandler {
     private String resolveNamespace(UserInfo userInfo, CdsData payload) {
         // Check payload for custom namespace (outbox-safe approach)
         if (payload != null) {
-            Object namespaceFromPayload = payload.get(NAMESPACE_ATTRIBUTE);
+            Object namespaceFromPayload = payload.get(AuditLogNG.NAMESPACE_ATTRIBUTE);
             if (namespaceFromPayload instanceof String ns && !ns.trim().isEmpty()) {
-                LOGGER.debug("Using custom namespace from payload '{}': {}", NAMESPACE_ATTRIBUTE, ns.trim());
+                LOGGER.debug("Using custom namespace from payload '{}': {}", AuditLogNG.NAMESPACE_ATTRIBUTE, ns.trim());
                 return ns.trim();
             }
         }

--- a/cds-feature-auditlog-ng/src/main/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandler.java
+++ b/cds-feature-auditlog-ng/src/main/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandler.java
@@ -8,7 +8,6 @@ import static org.slf4j.LoggerFactory.*;
 
 import java.time.Instant;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -52,10 +51,8 @@ import com.sap.cds.services.utils.ErrorStatusException;
  * Handler that reacts on audit log events to log audit messages with the auditlog NG API.
  *
  * <p>The namespace used in the event source can be customized per-request by setting
- * the user attribute {@value #NAMESPACE_ATTRIBUTE}. If this attribute is present and non-empty,
- * it will be used instead of the namespace from the service binding. This allows
- * applications with multiple commercial offerings to route audit events to different
- * namespaces dynamically.</p>
+ * the {@value #NAMESPACE_ATTRIBUTE} key in the event payload. This allows applications
+ * with multiple commercial offerings to route audit events to different namespaces dynamically.</p>
  */
 @ServiceName(value = "*", type = AuditLogService.class)
 public class AuditLogNGHandler implements EventHandler {
@@ -65,17 +62,13 @@ public class AuditLogNGHandler implements EventHandler {
     private static final String LEGACY_SECURITY_WRAPPER = "legacySecurityWrapper";
     
     /**
-     * Key name for specifying a custom namespace (used in both payload and UserInfo attributes).
+     * Key name for specifying a custom namespace in the event payload.
      * 
-     * <p><strong>Recommended approach (outbox-safe):</strong> Set this key directly in the
-     * event payload (e.g., {@code securityLog.put("auditlog.namespace", "my-namespace")}).
+     * <p>Set this key directly in the event payload 
+     * (e.g., {@code securityLog.put("auditlog.namespace", "my-namespace")}).
      * This approach survives transactional outbox serialization.</p>
      * 
-     * <p><strong>Deprecated approach:</strong> Setting via UserInfo attribute does NOT work
-     * reliably with the transactional outbox as user attributes may be lost during serialization.
-     * A warning will be logged when this approach is detected.</p>
-     * 
-     * <p>Resolution priority: payload &gt; UserInfo attribute &gt; service binding</p>
+     * <p>Resolution priority: payload &gt; service binding</p>
      */
     static final String NAMESPACE_ATTRIBUTE = "auditlog.namespace";
 
@@ -451,20 +444,17 @@ public class AuditLogNGHandler implements EventHandler {
      * 
      * <p>Resolution priority:</p>
      * <ol>
-     *   <li><strong>Payload (recommended):</strong> Checks if namespace is set in the event payload
+     *   <li><strong>Payload:</strong> Checks if namespace is set in the event payload
      *       via {@code payload.get("auditlog.namespace")}. This approach survives outbox serialization.</li>
-     *   <li><strong>UserInfo attribute (deprecated):</strong> Falls back to checking the user attribute
-     *       {@value #NAMESPACE_ATTRIBUTE}. A warning is logged as this approach does not work reliably
-     *       with the transactional outbox.</li>
      *   <li><strong>Service binding:</strong> Falls back to the namespace from the service binding.</li>
      * </ol>
      *
-     * @param userInfo the user information containing potential custom attributes
+     * @param userInfo the user information (kept for API compatibility)
      * @param payload the event payload (CdsData) that may contain a custom namespace, can be null
      * @return the namespace to use for the event source
      */
     private String resolveNamespace(UserInfo userInfo, CdsData payload) {
-        // Priority 1: Check payload (outbox-safe approach)
+        // Check payload for custom namespace (outbox-safe approach)
         if (payload != null) {
             Object namespaceFromPayload = payload.get(NAMESPACE_ATTRIBUTE);
             if (namespaceFromPayload instanceof String ns && !ns.trim().isEmpty()) {
@@ -473,20 +463,7 @@ public class AuditLogNGHandler implements EventHandler {
             }
         }
         
-        // Priority 2: Check UserInfo attributes (deprecated, doesn't survive outbox reliably)
-        List<String> namespaceValues = userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE);
-        if (namespaceValues != null && !namespaceValues.isEmpty()) {
-            String customNamespace = namespaceValues.get(0);
-            if (customNamespace != null && !customNamespace.trim().isEmpty()) {
-                LOGGER.warn("Using namespace from UserInfo attribute '{}'. " +
-                    "This approach is DEPRECATED and may NOT work with the transactional outbox. " +
-                    "Please set the namespace in the event payload instead (e.g., payload.put(\"{}\", \"my-namespace\")).", 
-                    NAMESPACE_ATTRIBUTE, NAMESPACE_ATTRIBUTE);
-                return customNamespace.trim();
-            }
-        }
-        
-        // Priority 3: Fall back to binding namespace
+        // Fall back to binding namespace
         LOGGER.debug("No custom namespace found, using binding namespace: {}", communicator.getNamespace());
         return communicator.getNamespace();
     }

--- a/cds-feature-auditlog-ng/src/test/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandlerTest.java
+++ b/cds-feature-auditlog-ng/src/test/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandlerTest.java
@@ -460,6 +460,228 @@ public class AuditLogNGHandlerTest {
             "Source should NOT contain second namespace value");
     }
 
+    // --- Tests for Payload-based Namespace (Outbox-safe approach) ---
+
+    @Test
+    public void testSecurityLog_UsesNamespaceFromPayload() throws Exception {
+        // Given: SecurityLog payload has custom namespace
+        when(communicator.getRegion()).thenReturn("eu10");
+        when(communicator.getNamespace()).thenReturn("binding-namespace");
+
+        SecurityLogContext context = mock(SecurityLogContext.class);
+        SecurityLog securityLog = mock(SecurityLog.class);
+        when(context.getUserInfo()).thenReturn(userInfo);
+        when(context.getData()).thenReturn(securityLog);
+        when(securityLog.getData()).thenReturn("test data");
+        when(securityLog.get(NAMESPACE_ATTRIBUTE)).thenReturn("payload-namespace");
+
+        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
+        handler.handleSecurityEvent(context);
+        verify(communicator).sendBulkRequest(captor.capture());
+
+        // Then: source should use namespace from payload
+        JsonNode event = captor.getValue().get(0);
+        String source = event.get("source").asText();
+        assertTrue(source.contains("/payload-namespace/"),
+            "Source should contain payload namespace, but was: " + source);
+    }
+
+    @Test
+    public void testDataAccessLog_UsesNamespaceFromPayload() throws Exception {
+        // Given: DataAccessLog payload has custom namespace
+        when(communicator.getRegion()).thenReturn("eu10");
+        when(communicator.getNamespace()).thenReturn("binding-namespace");
+
+        DataAccessLogContext context = mock(DataAccessLogContext.class);
+        DataAccessLog dataAccessLog = mock(DataAccessLog.class);
+        KeyValuePair id = mockKeyValuePair("userId", "user-1");
+        DataObject dataObject = mockDataObject("User", List.of(id));
+        DataSubject dataSubject = mockDataSubject("Person", List.of(id));
+        Attribute attr = mockAttribute("email");
+        Access access = mock(Access.class);
+        when(access.getDataObject()).thenReturn(dataObject);
+        when(access.getDataSubject()).thenReturn(dataSubject);
+        when(access.getAttributes()).thenReturn(List.of(attr));
+
+        when(dataAccessLog.getAccesses()).thenReturn(List.of(access));
+        when(dataAccessLog.get(NAMESPACE_ATTRIBUTE)).thenReturn("payload-namespace");
+        when(context.getData()).thenReturn(dataAccessLog);
+        when(context.getUserInfo()).thenReturn(userInfo);
+
+        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
+        handler.handleDataAccessEvent(context);
+        verify(communicator).sendBulkRequest(captor.capture());
+
+        // Then: source should use namespace from payload
+        JsonNode event = captor.getValue().get(0);
+        String source = event.get("source").asText();
+        assertTrue(source.contains("/payload-namespace/"),
+            "Source should contain payload namespace, but was: " + source);
+    }
+
+    @Test
+    public void testConfigChangeLog_UsesNamespaceFromPayload() throws Exception {
+        // Given: ConfigChangeLog payload has custom namespace
+        when(communicator.getRegion()).thenReturn("eu10");
+        when(communicator.getNamespace()).thenReturn("binding-namespace");
+
+        ConfigChangeLogContext context = mock(ConfigChangeLogContext.class);
+        ConfigChangeLog configChangeLog = mock(ConfigChangeLog.class);
+        ChangedAttribute attr = mockChangedAttribute("logLevel", "INFO", "DEBUG");
+        KeyValuePair id = mockKeyValuePair("appId", "app-1");
+        DataObject dataObject = mockDataObject("AppConfig", List.of(id));
+        ConfigChange config = mockConfigChange(List.of(attr), dataObject);
+
+        when(configChangeLog.getConfigurations()).thenReturn(List.of(config));
+        when(configChangeLog.get(NAMESPACE_ATTRIBUTE)).thenReturn("payload-namespace");
+        when(context.getData()).thenReturn(configChangeLog);
+        when(context.getUserInfo()).thenReturn(userInfo);
+
+        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
+        handler.handleConfigChangeEvent(context);
+        verify(communicator).sendBulkRequest(captor.capture());
+
+        // Then: source should use namespace from payload
+        JsonNode event = captor.getValue().get(0);
+        String source = event.get("source").asText();
+        assertTrue(source.contains("/payload-namespace/"),
+            "Source should contain payload namespace, but was: " + source);
+    }
+
+    @Test
+    public void testDataModificationLog_UsesNamespaceFromPayload() throws Exception {
+        // Given: DataModificationLog payload has custom namespace
+        when(communicator.getRegion()).thenReturn("eu10");
+        when(communicator.getNamespace()).thenReturn("binding-namespace");
+
+        DataModificationLogContext context = mock(DataModificationLogContext.class);
+        DataModificationLog dataModificationLog = mock(DataModificationLog.class);
+        ChangedAttribute attr = mockChangedAttribute("email", "old@example.com", "new@example.com");
+        KeyValuePair id = mockKeyValuePair("userId", "user-1");
+        DataObject dataObject = mockDataObject("User", List.of(id));
+        DataSubject dataSubject = mockDataSubject("Person", List.of(id));
+        DataModification modification = mockDataModification(List.of(attr), dataObject, dataSubject);
+
+        when(dataModificationLog.getModifications()).thenReturn(List.of(modification));
+        when(dataModificationLog.get(NAMESPACE_ATTRIBUTE)).thenReturn("payload-namespace");
+        when(context.getData()).thenReturn(dataModificationLog);
+        when(context.getUserInfo()).thenReturn(userInfo);
+
+        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
+        handler.handleDataModificationEvent(context);
+        verify(communicator).sendBulkRequest(captor.capture());
+
+        // Then: source should use namespace from payload
+        JsonNode event = captor.getValue().get(0);
+        String source = event.get("source").asText();
+        assertTrue(source.contains("/payload-namespace/"),
+            "Source should contain payload namespace, but was: " + source);
+    }
+
+    @Test
+    public void testPayloadNamespace_TakesPrecedence_OverUserInfoAttribute() throws Exception {
+        // Given: Both payload and UserInfo have namespace set
+        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE))
+            .thenReturn(List.of("userinfo-namespace"));
+        when(communicator.getRegion()).thenReturn("eu10");
+        when(communicator.getNamespace()).thenReturn("binding-namespace");
+
+        SecurityLogContext context = mock(SecurityLogContext.class);
+        SecurityLog securityLog = mock(SecurityLog.class);
+        when(context.getUserInfo()).thenReturn(userInfo);
+        when(context.getData()).thenReturn(securityLog);
+        when(securityLog.getData()).thenReturn("test data");
+        when(securityLog.get(NAMESPACE_ATTRIBUTE)).thenReturn("payload-namespace");
+
+        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
+        handler.handleSecurityEvent(context);
+        verify(communicator).sendBulkRequest(captor.capture());
+
+        // Then: payload namespace takes precedence
+        JsonNode event = captor.getValue().get(0);
+        String source = event.get("source").asText();
+        assertTrue(source.contains("/payload-namespace/"),
+            "Source should use payload namespace (higher priority), but was: " + source);
+        assertFalse(source.contains("/userinfo-namespace/"),
+            "Source should NOT use UserInfo namespace when payload is set");
+    }
+
+    @Test
+    public void testPayloadNamespace_TrimsWhitespace() throws Exception {
+        // Given: payload has namespace with leading/trailing whitespace
+        when(communicator.getRegion()).thenReturn("eu10");
+        when(communicator.getNamespace()).thenReturn("binding-namespace");
+
+        SecurityLogContext context = mock(SecurityLogContext.class);
+        SecurityLog securityLog = mock(SecurityLog.class);
+        when(context.getUserInfo()).thenReturn(userInfo);
+        when(context.getData()).thenReturn(securityLog);
+        when(securityLog.getData()).thenReturn("test data");
+        when(securityLog.get(NAMESPACE_ATTRIBUTE)).thenReturn("  trimmed-namespace  ");
+
+        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
+        handler.handleSecurityEvent(context);
+        verify(communicator).sendBulkRequest(captor.capture());
+
+        // Then: namespace should be trimmed
+        JsonNode event = captor.getValue().get(0);
+        String source = event.get("source").asText();
+        assertTrue(source.contains("/trimmed-namespace/"),
+            "Source should contain trimmed namespace, but was: " + source);
+        assertFalse(source.contains("  "),
+            "Source should not contain whitespace");
+    }
+
+    @Test
+    public void testPayloadNamespace_FallsBackToUserInfo_WhenPayloadEmpty() throws Exception {
+        // Given: payload namespace is empty string, but UserInfo has namespace
+        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE))
+            .thenReturn(List.of("userinfo-namespace"));
+        when(communicator.getRegion()).thenReturn("eu10");
+        when(communicator.getNamespace()).thenReturn("binding-namespace");
+
+        SecurityLogContext context = mock(SecurityLogContext.class);
+        SecurityLog securityLog = mock(SecurityLog.class);
+        when(context.getUserInfo()).thenReturn(userInfo);
+        when(context.getData()).thenReturn(securityLog);
+        when(securityLog.getData()).thenReturn("test data");
+        when(securityLog.get(NAMESPACE_ATTRIBUTE)).thenReturn("   ");
+
+        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
+        handler.handleSecurityEvent(context);
+        verify(communicator).sendBulkRequest(captor.capture());
+
+        // Then: should fall back to UserInfo namespace
+        JsonNode event = captor.getValue().get(0);
+        String source = event.get("source").asText();
+        assertTrue(source.contains("/userinfo-namespace/"),
+            "Source should fall back to UserInfo namespace when payload is blank, but was: " + source);
+    }
+
+    @Test
+    public void testPayloadNamespace_FallsBackToBinding_WhenPayloadNull() throws Exception {
+        // Given: payload namespace returns null
+        when(communicator.getRegion()).thenReturn("eu10");
+        when(communicator.getNamespace()).thenReturn("binding-namespace");
+
+        SecurityLogContext context = mock(SecurityLogContext.class);
+        SecurityLog securityLog = mock(SecurityLog.class);
+        when(context.getUserInfo()).thenReturn(userInfo);
+        when(context.getData()).thenReturn(securityLog);
+        when(securityLog.getData()).thenReturn("test data");
+        when(securityLog.get(NAMESPACE_ATTRIBUTE)).thenReturn(null);
+
+        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
+        handler.handleSecurityEvent(context);
+        verify(communicator).sendBulkRequest(captor.capture());
+
+        // Then: should fall back to binding namespace
+        JsonNode event = captor.getValue().get(0);
+        String source = event.get("source").asText();
+        assertTrue(source.contains("/binding-namespace/"),
+            "Source should fall back to binding namespace when payload is null, but was: " + source);
+    }
+
     private ChangedAttribute mockChangedAttribute(String name, String oldValue, String newValue) {
         ChangedAttribute attr = mock(ChangedAttribute.class);
         when(attr.getName()).thenReturn(name);

--- a/cds-feature-auditlog-ng/src/test/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandlerTest.java
+++ b/cds-feature-auditlog-ng/src/test/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandlerTest.java
@@ -3,8 +3,11 @@ package com.sap.cds.feature.auditlog.ng;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import static com.sap.cds.feature.auditlog.ng.AuditLogNGHandler.NAMESPACE_ATTRIBUTE;
+
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -292,6 +295,169 @@ public class AuditLogNGHandlerTest {
         JsonNode wrapped = dataNode.get("dataExport");
         Assertions.assertEquals("UNSPECIFIED", wrapped.get("channelType").asText());
         Assertions.assertEquals("string", wrapped.get("channelId").asText());
+    }
+
+    // --- Tests for Dynamic Namespace Resolution ---
+
+    @Test
+    public void testHandleEvent_UsesCustomNamespaceFromUserAttribute() throws Exception {
+        // Given: userInfo has custom namespace attribute
+        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE))
+            .thenReturn(List.of("custom-namespace"));
+        when(communicator.getRegion()).thenReturn("eu10");
+        when(communicator.getNamespace()).thenReturn("binding-namespace");
+
+        // When: handle a security event
+        SecurityLogContext context = mock(SecurityLogContext.class);
+        SecurityLog securityLog = mock(SecurityLog.class);
+        when(context.getUserInfo()).thenReturn(userInfo);
+        when(context.getData()).thenReturn(securityLog);
+        when(securityLog.getData()).thenReturn("test data");
+
+        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
+        handler.handleSecurityEvent(context);
+        verify(communicator).sendBulkRequest(captor.capture());
+
+        // Then: source should use custom namespace
+        JsonNode event = captor.getValue().get(0);
+        String source = event.get("source").asText();
+        assertTrue(source.contains("/custom-namespace/"),
+            "Source should contain custom namespace, but was: " + source);
+        assertFalse(source.contains("/binding-namespace/"),
+            "Source should NOT contain binding namespace");
+    }
+
+    @Test
+    public void testHandleEvent_FallsBackToBindingNamespace_WhenAttributeEmpty() throws Exception {
+        // Given: userInfo has empty namespace attribute list
+        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE))
+            .thenReturn(Collections.emptyList());
+        when(communicator.getRegion()).thenReturn("eu10");
+        when(communicator.getNamespace()).thenReturn("binding-namespace");
+
+        // When: handle a security event
+        SecurityLogContext context = mock(SecurityLogContext.class);
+        SecurityLog securityLog = mock(SecurityLog.class);
+        when(context.getUserInfo()).thenReturn(userInfo);
+        when(context.getData()).thenReturn(securityLog);
+        when(securityLog.getData()).thenReturn("test data");
+
+        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
+        handler.handleSecurityEvent(context);
+        verify(communicator).sendBulkRequest(captor.capture());
+
+        // Then: source should use binding namespace
+        JsonNode event = captor.getValue().get(0);
+        String source = event.get("source").asText();
+        assertTrue(source.contains("/binding-namespace/"),
+            "Source should contain binding namespace when attribute is empty, but was: " + source);
+    }
+
+    @Test
+    public void testHandleEvent_FallsBackToBindingNamespace_WhenAttributeNull() throws Exception {
+        // Given: userInfo returns null for namespace attribute
+        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE)).thenReturn(null);
+        when(communicator.getRegion()).thenReturn("eu10");
+        when(communicator.getNamespace()).thenReturn("binding-namespace");
+
+        // When: handle a security event
+        SecurityLogContext context = mock(SecurityLogContext.class);
+        SecurityLog securityLog = mock(SecurityLog.class);
+        when(context.getUserInfo()).thenReturn(userInfo);
+        when(context.getData()).thenReturn(securityLog);
+        when(securityLog.getData()).thenReturn("test data");
+
+        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
+        handler.handleSecurityEvent(context);
+        verify(communicator).sendBulkRequest(captor.capture());
+
+        // Then: source should use binding namespace
+        JsonNode event = captor.getValue().get(0);
+        String source = event.get("source").asText();
+        assertTrue(source.contains("/binding-namespace/"),
+            "Source should contain binding namespace when attribute is null, but was: " + source);
+    }
+
+    @Test
+    public void testHandleEvent_FallsBackToBindingNamespace_WhenAttributeValueBlank() throws Exception {
+        // Given: userInfo has whitespace-only namespace attribute
+        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE))
+            .thenReturn(List.of("   "));
+        when(communicator.getRegion()).thenReturn("eu10");
+        when(communicator.getNamespace()).thenReturn("binding-namespace");
+
+        // When: handle a security event
+        SecurityLogContext context = mock(SecurityLogContext.class);
+        SecurityLog securityLog = mock(SecurityLog.class);
+        when(context.getUserInfo()).thenReturn(userInfo);
+        when(context.getData()).thenReturn(securityLog);
+        when(securityLog.getData()).thenReturn("test data");
+
+        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
+        handler.handleSecurityEvent(context);
+        verify(communicator).sendBulkRequest(captor.capture());
+
+        // Then: source should use binding namespace (blank is treated as empty)
+        JsonNode event = captor.getValue().get(0);
+        String source = event.get("source").asText();
+        assertTrue(source.contains("/binding-namespace/"),
+            "Source should contain binding namespace when attribute is blank, but was: " + source);
+    }
+
+    @Test
+    public void testHandleEvent_TrimsCustomNamespace() throws Exception {
+        // Given: userInfo has namespace attribute with leading/trailing whitespace
+        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE))
+            .thenReturn(List.of("  trimmed-namespace  "));
+        when(communicator.getRegion()).thenReturn("eu10");
+        when(communicator.getNamespace()).thenReturn("binding-namespace");
+
+        // When: handle a security event
+        SecurityLogContext context = mock(SecurityLogContext.class);
+        SecurityLog securityLog = mock(SecurityLog.class);
+        when(context.getUserInfo()).thenReturn(userInfo);
+        when(context.getData()).thenReturn(securityLog);
+        when(securityLog.getData()).thenReturn("test data");
+
+        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
+        handler.handleSecurityEvent(context);
+        verify(communicator).sendBulkRequest(captor.capture());
+
+        // Then: source should use trimmed custom namespace
+        JsonNode event = captor.getValue().get(0);
+        String source = event.get("source").asText();
+        assertTrue(source.contains("/trimmed-namespace/"),
+            "Source should contain trimmed namespace, but was: " + source);
+        assertFalse(source.contains("  "),
+            "Source should not contain extra whitespace");
+    }
+
+    @Test
+    public void testHandleEvent_UsesFirstValueWhenMultipleProvided() throws Exception {
+        // Given: userInfo has multiple namespace values (uses first one)
+        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE))
+            .thenReturn(List.of("first-namespace", "second-namespace"));
+        when(communicator.getRegion()).thenReturn("eu10");
+        when(communicator.getNamespace()).thenReturn("binding-namespace");
+
+        // When: handle a security event
+        SecurityLogContext context = mock(SecurityLogContext.class);
+        SecurityLog securityLog = mock(SecurityLog.class);
+        when(context.getUserInfo()).thenReturn(userInfo);
+        when(context.getData()).thenReturn(securityLog);
+        when(securityLog.getData()).thenReturn("test data");
+
+        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
+        handler.handleSecurityEvent(context);
+        verify(communicator).sendBulkRequest(captor.capture());
+
+        // Then: source should use first namespace value
+        JsonNode event = captor.getValue().get(0);
+        String source = event.get("source").asText();
+        assertTrue(source.contains("/first-namespace/"),
+            "Source should contain first namespace value, but was: " + source);
+        assertFalse(source.contains("/second-namespace/"),
+            "Source should NOT contain second namespace value");
     }
 
     private ChangedAttribute mockChangedAttribute(String name, String oldValue, String newValue) {

--- a/cds-feature-auditlog-ng/src/test/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandlerTest.java
+++ b/cds-feature-auditlog-ng/src/test/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandlerTest.java
@@ -3,7 +3,7 @@ package com.sap.cds.feature.auditlog.ng;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import static com.sap.cds.feature.auditlog.ng.AuditLogNGHandler.NAMESPACE_ATTRIBUTE;
+import static com.sap.cds.feature.auditlog.ng.AuditLogNG.NAMESPACE_ATTRIBUTE;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/cds-feature-auditlog-ng/src/test/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandlerTest.java
+++ b/cds-feature-auditlog-ng/src/test/java/com/sap/cds/feature/auditlog/ng/AuditLogNGHandlerTest.java
@@ -7,7 +7,6 @@ import static com.sap.cds.feature.auditlog.ng.AuditLogNGHandler.NAMESPACE_ATTRIB
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -297,170 +296,7 @@ public class AuditLogNGHandlerTest {
         Assertions.assertEquals("string", wrapped.get("channelId").asText());
     }
 
-    // --- Tests for Dynamic Namespace Resolution ---
-
-    @Test
-    public void testHandleEvent_UsesCustomNamespaceFromUserAttribute() throws Exception {
-        // Given: userInfo has custom namespace attribute
-        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE))
-            .thenReturn(List.of("custom-namespace"));
-        when(communicator.getRegion()).thenReturn("eu10");
-        when(communicator.getNamespace()).thenReturn("binding-namespace");
-
-        // When: handle a security event
-        SecurityLogContext context = mock(SecurityLogContext.class);
-        SecurityLog securityLog = mock(SecurityLog.class);
-        when(context.getUserInfo()).thenReturn(userInfo);
-        when(context.getData()).thenReturn(securityLog);
-        when(securityLog.getData()).thenReturn("test data");
-
-        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
-        handler.handleSecurityEvent(context);
-        verify(communicator).sendBulkRequest(captor.capture());
-
-        // Then: source should use custom namespace
-        JsonNode event = captor.getValue().get(0);
-        String source = event.get("source").asText();
-        assertTrue(source.contains("/custom-namespace/"),
-            "Source should contain custom namespace, but was: " + source);
-        assertFalse(source.contains("/binding-namespace/"),
-            "Source should NOT contain binding namespace");
-    }
-
-    @Test
-    public void testHandleEvent_FallsBackToBindingNamespace_WhenAttributeEmpty() throws Exception {
-        // Given: userInfo has empty namespace attribute list
-        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE))
-            .thenReturn(Collections.emptyList());
-        when(communicator.getRegion()).thenReturn("eu10");
-        when(communicator.getNamespace()).thenReturn("binding-namespace");
-
-        // When: handle a security event
-        SecurityLogContext context = mock(SecurityLogContext.class);
-        SecurityLog securityLog = mock(SecurityLog.class);
-        when(context.getUserInfo()).thenReturn(userInfo);
-        when(context.getData()).thenReturn(securityLog);
-        when(securityLog.getData()).thenReturn("test data");
-
-        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
-        handler.handleSecurityEvent(context);
-        verify(communicator).sendBulkRequest(captor.capture());
-
-        // Then: source should use binding namespace
-        JsonNode event = captor.getValue().get(0);
-        String source = event.get("source").asText();
-        assertTrue(source.contains("/binding-namespace/"),
-            "Source should contain binding namespace when attribute is empty, but was: " + source);
-    }
-
-    @Test
-    public void testHandleEvent_FallsBackToBindingNamespace_WhenAttributeNull() throws Exception {
-        // Given: userInfo returns null for namespace attribute
-        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE)).thenReturn(null);
-        when(communicator.getRegion()).thenReturn("eu10");
-        when(communicator.getNamespace()).thenReturn("binding-namespace");
-
-        // When: handle a security event
-        SecurityLogContext context = mock(SecurityLogContext.class);
-        SecurityLog securityLog = mock(SecurityLog.class);
-        when(context.getUserInfo()).thenReturn(userInfo);
-        when(context.getData()).thenReturn(securityLog);
-        when(securityLog.getData()).thenReturn("test data");
-
-        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
-        handler.handleSecurityEvent(context);
-        verify(communicator).sendBulkRequest(captor.capture());
-
-        // Then: source should use binding namespace
-        JsonNode event = captor.getValue().get(0);
-        String source = event.get("source").asText();
-        assertTrue(source.contains("/binding-namespace/"),
-            "Source should contain binding namespace when attribute is null, but was: " + source);
-    }
-
-    @Test
-    public void testHandleEvent_FallsBackToBindingNamespace_WhenAttributeValueBlank() throws Exception {
-        // Given: userInfo has whitespace-only namespace attribute
-        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE))
-            .thenReturn(List.of("   "));
-        when(communicator.getRegion()).thenReturn("eu10");
-        when(communicator.getNamespace()).thenReturn("binding-namespace");
-
-        // When: handle a security event
-        SecurityLogContext context = mock(SecurityLogContext.class);
-        SecurityLog securityLog = mock(SecurityLog.class);
-        when(context.getUserInfo()).thenReturn(userInfo);
-        when(context.getData()).thenReturn(securityLog);
-        when(securityLog.getData()).thenReturn("test data");
-
-        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
-        handler.handleSecurityEvent(context);
-        verify(communicator).sendBulkRequest(captor.capture());
-
-        // Then: source should use binding namespace (blank is treated as empty)
-        JsonNode event = captor.getValue().get(0);
-        String source = event.get("source").asText();
-        assertTrue(source.contains("/binding-namespace/"),
-            "Source should contain binding namespace when attribute is blank, but was: " + source);
-    }
-
-    @Test
-    public void testHandleEvent_TrimsCustomNamespace() throws Exception {
-        // Given: userInfo has namespace attribute with leading/trailing whitespace
-        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE))
-            .thenReturn(List.of("  trimmed-namespace  "));
-        when(communicator.getRegion()).thenReturn("eu10");
-        when(communicator.getNamespace()).thenReturn("binding-namespace");
-
-        // When: handle a security event
-        SecurityLogContext context = mock(SecurityLogContext.class);
-        SecurityLog securityLog = mock(SecurityLog.class);
-        when(context.getUserInfo()).thenReturn(userInfo);
-        when(context.getData()).thenReturn(securityLog);
-        when(securityLog.getData()).thenReturn("test data");
-
-        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
-        handler.handleSecurityEvent(context);
-        verify(communicator).sendBulkRequest(captor.capture());
-
-        // Then: source should use trimmed custom namespace
-        JsonNode event = captor.getValue().get(0);
-        String source = event.get("source").asText();
-        assertTrue(source.contains("/trimmed-namespace/"),
-            "Source should contain trimmed namespace, but was: " + source);
-        assertFalse(source.contains("  "),
-            "Source should not contain extra whitespace");
-    }
-
-    @Test
-    public void testHandleEvent_UsesFirstValueWhenMultipleProvided() throws Exception {
-        // Given: userInfo has multiple namespace values (uses first one)
-        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE))
-            .thenReturn(List.of("first-namespace", "second-namespace"));
-        when(communicator.getRegion()).thenReturn("eu10");
-        when(communicator.getNamespace()).thenReturn("binding-namespace");
-
-        // When: handle a security event
-        SecurityLogContext context = mock(SecurityLogContext.class);
-        SecurityLog securityLog = mock(SecurityLog.class);
-        when(context.getUserInfo()).thenReturn(userInfo);
-        when(context.getData()).thenReturn(securityLog);
-        when(securityLog.getData()).thenReturn("test data");
-
-        ArgumentCaptor<ArrayNode> captor = ArgumentCaptor.forClass(ArrayNode.class);
-        handler.handleSecurityEvent(context);
-        verify(communicator).sendBulkRequest(captor.capture());
-
-        // Then: source should use first namespace value
-        JsonNode event = captor.getValue().get(0);
-        String source = event.get("source").asText();
-        assertTrue(source.contains("/first-namespace/"),
-            "Source should contain first namespace value, but was: " + source);
-        assertFalse(source.contains("/second-namespace/"),
-            "Source should NOT contain second namespace value");
-    }
-
-    // --- Tests for Payload-based Namespace (Outbox-safe approach) ---
+    // --- Tests for Payload-based Namespace ---
 
     @Test
     public void testSecurityLog_UsesNamespaceFromPayload() throws Exception {
@@ -579,10 +415,8 @@ public class AuditLogNGHandlerTest {
     }
 
     @Test
-    public void testPayloadNamespace_TakesPrecedence_OverUserInfoAttribute() throws Exception {
-        // Given: Both payload and UserInfo have namespace set
-        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE))
-            .thenReturn(List.of("userinfo-namespace"));
+    public void testPayloadNamespace_TakesPrecedence_OverBindingNamespace() throws Exception {
+        // Given: Both payload and binding have namespace
         when(communicator.getRegion()).thenReturn("eu10");
         when(communicator.getNamespace()).thenReturn("binding-namespace");
 
@@ -597,13 +431,13 @@ public class AuditLogNGHandlerTest {
         handler.handleSecurityEvent(context);
         verify(communicator).sendBulkRequest(captor.capture());
 
-        // Then: payload namespace takes precedence
+        // Then: payload namespace takes precedence over binding
         JsonNode event = captor.getValue().get(0);
         String source = event.get("source").asText();
         assertTrue(source.contains("/payload-namespace/"),
             "Source should use payload namespace (higher priority), but was: " + source);
-        assertFalse(source.contains("/userinfo-namespace/"),
-            "Source should NOT use UserInfo namespace when payload is set");
+        assertFalse(source.contains("/binding-namespace/"),
+            "Source should NOT use binding namespace when payload is set");
     }
 
     @Test
@@ -633,10 +467,8 @@ public class AuditLogNGHandlerTest {
     }
 
     @Test
-    public void testPayloadNamespace_FallsBackToUserInfo_WhenPayloadEmpty() throws Exception {
-        // Given: payload namespace is empty string, but UserInfo has namespace
-        when(userInfo.getAttributeValues(NAMESPACE_ATTRIBUTE))
-            .thenReturn(List.of("userinfo-namespace"));
+    public void testPayloadNamespace_FallsBackToBinding_WhenPayloadEmpty() throws Exception {
+        // Given: payload namespace is empty/whitespace string
         when(communicator.getRegion()).thenReturn("eu10");
         when(communicator.getNamespace()).thenReturn("binding-namespace");
 
@@ -651,11 +483,11 @@ public class AuditLogNGHandlerTest {
         handler.handleSecurityEvent(context);
         verify(communicator).sendBulkRequest(captor.capture());
 
-        // Then: should fall back to UserInfo namespace
+        // Then: should fall back to binding namespace
         JsonNode event = captor.getValue().get(0);
         String source = event.get("source").asText();
-        assertTrue(source.contains("/userinfo-namespace/"),
-            "Source should fall back to UserInfo namespace when payload is blank, but was: " + source);
+        assertTrue(source.contains("/binding-namespace/"),
+            "Source should fall back to binding namespace when payload is blank, but was: " + source);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </developers>
 
   <properties>
-    <revision>0.0.3</revision>
+    <revision>0.0.3-SNAPSHOT</revision>
     <java.version>17</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </developers>
 
   <properties>
-    <revision>0.0.3-SNAPSHOT</revision>
+    <revision>0.0.4</revision>
     <java.version>17</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </developers>
 
   <properties>
-    <revision>0.0.4</revision>
+    <revision>0.0.4-SNAPSHOT</revision>
     <java.version>17</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
### Summary
Adds support for dynamically selecting the audit log namespace per-event via the event payload.
### Changes
- New AuditLogNG interface exposing NAMESPACE_ATTRIBUTE constant
- Namespace can be set in event payload: event.put(AuditLogNG.NAMESPACE_ATTRIBUTE, "my-namespace")
- Payload-based approach survives transactional outbox serialization
- Resolution priority: Payload → Service binding
- Updated README with usage documentation and error handling guidance