### PR TITLE
fix(fips): swap bcprov-jdk18on for bc-fips to enable FIPS 140-3 compliance

### DIFF
--- a/cds-feature-auditlog-ng/src/main/java/com/sap/cds/feature/auditlog/ng/CertificateHttpClientConfig.java
+++ b/cds-feature-auditlog-ng/src/main/java/com/sap/cds/feature/auditlog/ng/CertificateHttpClientConfig.java
@@ -24,7 +24,7 @@ import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClients;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.cert.X509CertificateHolder;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8DecryptorProviderBuilder;
 import org.bouncycastle.operator.InputDecryptorProvider;
@@ -52,9 +52,9 @@ public class CertificateHttpClientConfig {
     private static final Logger logger = LoggerFactory.getLogger(CertificateHttpClientConfig.class);
 
     static {
-        // Register BouncyCastle provider if not already present
-        if (Security.getProvider("BC") == null) {
-            Security.addProvider(new BouncyCastleProvider());
+        // Register BouncyCastle FIPS provider if not already present
+        if (Security.getProvider("BCFIPS") == null) {
+            Security.addProvider(new BouncyCastleFipsProvider());
         }
     }
 
@@ -170,11 +170,11 @@ public class CertificateHttpClientConfig {
     private CloseableHttpClient createHttpClient() {
         try {
             char[] effectivePassphrase = (keyPassphrase != null) ? keyPassphrase.toCharArray() : new char[0];
-            logger.info("Creating HttpClient with certificate authentication and {} retries", maxRetries);
+            logger.info("Creating HttpClient with certificate authentication and {} retries (BCFIPS)", maxRetries);
             X509Certificate[] certChain = parseCertificateChain(certPem);
             PrivateKey privateKey = parsePrivateKey(keyPem, effectivePassphrase);
 
-            KeyStore keyStore = KeyStore.getInstance("PKCS12");
+            KeyStore keyStore = KeyStore.getInstance("PKCS12", "BCFIPS");
             keyStore.load(null, null);
             keyStore.setKeyEntry("client", privateKey, new char[0], certChain);
 
@@ -237,7 +237,7 @@ public class CertificateHttpClientConfig {
                 return KeyFactory.getInstance("RSA").generatePrivate(keySpec);
             } else if (object instanceof PKCS8EncryptedPrivateKeyInfo encInfo) {
                 try {
-                    InputDecryptorProvider decryptorProvider = new JceOpenSSLPKCS8DecryptorProviderBuilder().build(effectivePassphrase);
+                    InputDecryptorProvider decryptorProvider = new JceOpenSSLPKCS8DecryptorProviderBuilder().setProvider("BCFIPS").build(effectivePassphrase);
                     PrivateKeyInfo keyInfo = encInfo.decryptPrivateKeyInfo(decryptorProvider);
                     PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyInfo.getEncoded());
                     return KeyFactory.getInstance("RSA").generatePrivate(keySpec);

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,10 @@
     <mockito.version>5.18.0</mockito.version>
     <sdk-bom.version>5.25.0</sdk-bom.version>
     <mockito-bom.version>5.21.0</mockito-bom.version>
-    <bcpkix-jdk18on.version>1.83</bcpkix-jdk18on.version>
+    <bc-fips.version>2.1.3</bc-fips.version>
+    <bcpkix-fips.version>2.1.8</bcpkix-fips.version>
+    <bctls-fips.version>2.1.20</bctls-fips.version>
+    <bcutil-fips.version>2.1.5</bcutil-fips.version>
   </properties>
 
   <groupId>com.sap.cds</groupId>
@@ -85,14 +88,26 @@
   <dependencies>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk18on</artifactId>
-      <version>${bcpkix-jdk18on.version}</version>
+      <artifactId>bc-fips</artifactId>
+      <version>${bc-fips.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk18on</artifactId>
-      <version>${bcpkix-jdk18on.version}</version>
+      <artifactId>bcpkix-fips</artifactId>
+      <version>${bcpkix-fips.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bctls-fips</artifactId>
+      <version>${bctls-fips.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcutil-fips</artifactId>
+      <version>${bcutil-fips.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Motivation

The plugin currently pulls `org.bouncycastle:bcpkix-jdk18on` (non-FIPS). Consumers targeting FIPS 140-3 / SAP NS2 environments need the FIPS-validated `bc-fips` distribution instead. Downstream tracking: RBSALSRV-511 (internal).

## Change

- `pom.xml`: swap `bcprov-jdk18on` + `bcpkix-jdk18on` for `bc-fips` + `bcpkix-fips` + `bctls-fips` + `bcutil-fips`.
- `CertificateHttpClientConfig`: `BouncyCastleProvider` → `BouncyCastleFipsProvider`.

## Verification

- `mvn clean verify` passes locally.
- Downstream compatibility verified in an internal shim before opening this PR.

## Reviewers

@mtsvetanov071 @georgi-shakev @lisajulia — happy to include this in the 0.0.5 release cut following #131 if it fits.